### PR TITLE
Fix kernel module directory detection

### DIFF
--- a/build-modules.sh
+++ b/build-modules.sh
@@ -3,10 +3,11 @@
 echo "Building ./modules/ floppy folder..."
 
 rm -rf ./modules
+kernel_version=$(make -s -C linux-5.17.2 kernelrelease)
 INSTALL_MOD_PATH=$(pwd)/modules make -C linux-5.17.2 modules_install
-mv modules/lib/modules/* modules/
+mv "modules/lib/modules/${kernel_version}" modules/
 rmdir modules/lib/modules modules/lib
-rm modules/5.17.2clyne/{source,build}
+rm modules/${kernel_version}/{source,build}
 find modules/ -type f -name "*.ko" -exec strip --strip-debug {} \;
 du -sh ./modules
 


### PR DESCRIPTION
## Summary
- update `build-modules.sh` to detect kernel version
- clean up module build artifacts using the detected version

## Testing
- `git status --short`