### PR TITLE
Improve build script reliability

### DIFF
--- a/build-busybox.sh
+++ b/build-busybox.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 if [ ! -e ./busybox-1.20.0.tar.bz2 ] ; then
     echo "Fetching busybox..."

--- a/build-floppy.sh
+++ b/build-floppy.sh
@@ -1,4 +1,16 @@
 #!/bin/bash
+set -euo pipefail
+
+cleanup() {
+    if mountpoint -q /mnt/dev; then
+        sudo umount /mnt/dev
+        sudo rmdir /mnt/dev
+    fi
+    if mountpoint -q /mnt; then
+        sudo umount /mnt
+    fi
+}
+trap cleanup EXIT
 
 dd if=/dev/zero of=floppy.img bs=1k count=1440
 mkfs.ext2 -b 1024 -i 65536 -I 128 -m 0 -r 0 -T floppy -d floppy floppy.img

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 if [ ! -e ./linux-5.17.2.tar.xz ] ; then
     echo "Fetching Linux..."

--- a/build-modules.sh
+++ b/build-modules.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -euo pipefail
+
+cleanup() {
+    if mountpoint -q /mnt; then
+        sudo umount /mnt
+    fi
+}
+trap cleanup EXIT
 
 echo "Building ./modules/ floppy folder..."
 

--- a/build-toolchain.sh
+++ b/build-toolchain.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 if [ ! -e ./buildroot-2022.02.1.tar.xz ] ; then
     echo "Fetching buildroot..."


### PR DESCRIPTION
## Summary
- enable strict bash mode in all build scripts
- ensure loop devices are unmounted on failure via traps

## Testing
- `git status --short`