### PR TITLE
Clean up preinit header artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ floppy/lib/
 modules.img
 modules/
 preinit/init
+preinit/linux-headers/**/*.cmd

--- a/preinit/linux-headers/asm-generic/.auxvec.h.cmd
+++ b/preinit/linux-headers/asm-generic/.auxvec.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/auxvec.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/auxvec.h usr/include/asm-generic/auxvec.h

--- a/preinit/linux-headers/asm-generic/.bitsperlong.h.cmd
+++ b/preinit/linux-headers/asm-generic/.bitsperlong.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/bitsperlong.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/bitsperlong.h usr/include/asm-generic/bitsperlong.h

--- a/preinit/linux-headers/asm-generic/.bpf_perf_event.h.cmd
+++ b/preinit/linux-headers/asm-generic/.bpf_perf_event.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/bpf_perf_event.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/bpf_perf_event.h usr/include/asm-generic/bpf_perf_event.h

--- a/preinit/linux-headers/asm-generic/.errno-base.h.cmd
+++ b/preinit/linux-headers/asm-generic/.errno-base.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/errno-base.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/errno-base.h usr/include/asm-generic/errno-base.h

--- a/preinit/linux-headers/asm-generic/.errno.h.cmd
+++ b/preinit/linux-headers/asm-generic/.errno.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/errno.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/errno.h usr/include/asm-generic/errno.h

--- a/preinit/linux-headers/asm-generic/.fcntl.h.cmd
+++ b/preinit/linux-headers/asm-generic/.fcntl.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/fcntl.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/fcntl.h usr/include/asm-generic/fcntl.h

--- a/preinit/linux-headers/asm-generic/.hugetlb_encode.h.cmd
+++ b/preinit/linux-headers/asm-generic/.hugetlb_encode.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/hugetlb_encode.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/hugetlb_encode.h usr/include/asm-generic/hugetlb_encode.h

--- a/preinit/linux-headers/asm-generic/.int-l64.h.cmd
+++ b/preinit/linux-headers/asm-generic/.int-l64.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/int-l64.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/int-l64.h usr/include/asm-generic/int-l64.h

--- a/preinit/linux-headers/asm-generic/.int-ll64.h.cmd
+++ b/preinit/linux-headers/asm-generic/.int-ll64.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/int-ll64.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/int-ll64.h usr/include/asm-generic/int-ll64.h

--- a/preinit/linux-headers/asm-generic/.ioctl.h.cmd
+++ b/preinit/linux-headers/asm-generic/.ioctl.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/ioctl.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/ioctl.h usr/include/asm-generic/ioctl.h

--- a/preinit/linux-headers/asm-generic/.ioctls.h.cmd
+++ b/preinit/linux-headers/asm-generic/.ioctls.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/ioctls.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/ioctls.h usr/include/asm-generic/ioctls.h

--- a/preinit/linux-headers/asm-generic/.ipcbuf.h.cmd
+++ b/preinit/linux-headers/asm-generic/.ipcbuf.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/ipcbuf.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/ipcbuf.h usr/include/asm-generic/ipcbuf.h

--- a/preinit/linux-headers/asm-generic/.kvm_para.h.cmd
+++ b/preinit/linux-headers/asm-generic/.kvm_para.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/kvm_para.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/kvm_para.h usr/include/asm-generic/kvm_para.h

--- a/preinit/linux-headers/asm-generic/.mman-common.h.cmd
+++ b/preinit/linux-headers/asm-generic/.mman-common.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/mman-common.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/mman-common.h usr/include/asm-generic/mman-common.h

--- a/preinit/linux-headers/asm-generic/.mman.h.cmd
+++ b/preinit/linux-headers/asm-generic/.mman.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/mman.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/mman.h usr/include/asm-generic/mman.h

--- a/preinit/linux-headers/asm-generic/.msgbuf.h.cmd
+++ b/preinit/linux-headers/asm-generic/.msgbuf.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/msgbuf.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/msgbuf.h usr/include/asm-generic/msgbuf.h

--- a/preinit/linux-headers/asm-generic/.param.h.cmd
+++ b/preinit/linux-headers/asm-generic/.param.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/param.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/param.h usr/include/asm-generic/param.h

--- a/preinit/linux-headers/asm-generic/.poll.h.cmd
+++ b/preinit/linux-headers/asm-generic/.poll.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/poll.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/poll.h usr/include/asm-generic/poll.h

--- a/preinit/linux-headers/asm-generic/.posix_types.h.cmd
+++ b/preinit/linux-headers/asm-generic/.posix_types.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/posix_types.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/posix_types.h usr/include/asm-generic/posix_types.h

--- a/preinit/linux-headers/asm-generic/.resource.h.cmd
+++ b/preinit/linux-headers/asm-generic/.resource.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/resource.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/resource.h usr/include/asm-generic/resource.h

--- a/preinit/linux-headers/asm-generic/.sembuf.h.cmd
+++ b/preinit/linux-headers/asm-generic/.sembuf.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/sembuf.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/sembuf.h usr/include/asm-generic/sembuf.h

--- a/preinit/linux-headers/asm-generic/.setup.h.cmd
+++ b/preinit/linux-headers/asm-generic/.setup.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/setup.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/setup.h usr/include/asm-generic/setup.h

--- a/preinit/linux-headers/asm-generic/.shmbuf.h.cmd
+++ b/preinit/linux-headers/asm-generic/.shmbuf.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/shmbuf.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/shmbuf.h usr/include/asm-generic/shmbuf.h

--- a/preinit/linux-headers/asm-generic/.siginfo.h.cmd
+++ b/preinit/linux-headers/asm-generic/.siginfo.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/siginfo.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/siginfo.h usr/include/asm-generic/siginfo.h

--- a/preinit/linux-headers/asm-generic/.signal-defs.h.cmd
+++ b/preinit/linux-headers/asm-generic/.signal-defs.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/signal-defs.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/signal-defs.h usr/include/asm-generic/signal-defs.h

--- a/preinit/linux-headers/asm-generic/.signal.h.cmd
+++ b/preinit/linux-headers/asm-generic/.signal.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/signal.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/signal.h usr/include/asm-generic/signal.h

--- a/preinit/linux-headers/asm-generic/.socket.h.cmd
+++ b/preinit/linux-headers/asm-generic/.socket.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/socket.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/socket.h usr/include/asm-generic/socket.h

--- a/preinit/linux-headers/asm-generic/.sockios.h.cmd
+++ b/preinit/linux-headers/asm-generic/.sockios.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/sockios.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/sockios.h usr/include/asm-generic/sockios.h

--- a/preinit/linux-headers/asm-generic/.stat.h.cmd
+++ b/preinit/linux-headers/asm-generic/.stat.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/stat.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/stat.h usr/include/asm-generic/stat.h

--- a/preinit/linux-headers/asm-generic/.statfs.h.cmd
+++ b/preinit/linux-headers/asm-generic/.statfs.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/statfs.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/statfs.h usr/include/asm-generic/statfs.h

--- a/preinit/linux-headers/asm-generic/.swab.h.cmd
+++ b/preinit/linux-headers/asm-generic/.swab.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/swab.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/swab.h usr/include/asm-generic/swab.h

--- a/preinit/linux-headers/asm-generic/.termbits.h.cmd
+++ b/preinit/linux-headers/asm-generic/.termbits.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/termbits.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/termbits.h usr/include/asm-generic/termbits.h

--- a/preinit/linux-headers/asm-generic/.termios.h.cmd
+++ b/preinit/linux-headers/asm-generic/.termios.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/termios.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/termios.h usr/include/asm-generic/termios.h

--- a/preinit/linux-headers/asm-generic/.types.h.cmd
+++ b/preinit/linux-headers/asm-generic/.types.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/types.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/types.h usr/include/asm-generic/types.h

--- a/preinit/linux-headers/asm-generic/.ucontext.h.cmd
+++ b/preinit/linux-headers/asm-generic/.ucontext.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/ucontext.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/ucontext.h usr/include/asm-generic/ucontext.h

--- a/preinit/linux-headers/asm-generic/.unistd.h.cmd
+++ b/preinit/linux-headers/asm-generic/.unistd.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm-generic/unistd.h := sh ./scripts/headers_install.sh include/uapi/asm-generic/unistd.h usr/include/asm-generic/unistd.h

--- a/preinit/linux-headers/asm/.a.out.h.cmd
+++ b/preinit/linux-headers/asm/.a.out.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/a.out.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/a.out.h usr/include/asm/a.out.h

--- a/preinit/linux-headers/asm/.auxvec.h.cmd
+++ b/preinit/linux-headers/asm/.auxvec.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/auxvec.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/auxvec.h usr/include/asm/auxvec.h

--- a/preinit/linux-headers/asm/.bitsperlong.h.cmd
+++ b/preinit/linux-headers/asm/.bitsperlong.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/bitsperlong.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/bitsperlong.h usr/include/asm/bitsperlong.h

--- a/preinit/linux-headers/asm/.boot.h.cmd
+++ b/preinit/linux-headers/asm/.boot.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/boot.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/boot.h usr/include/asm/boot.h

--- a/preinit/linux-headers/asm/.bootparam.h.cmd
+++ b/preinit/linux-headers/asm/.bootparam.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/bootparam.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/bootparam.h usr/include/asm/bootparam.h

--- a/preinit/linux-headers/asm/.bpf_perf_event.h.cmd
+++ b/preinit/linux-headers/asm/.bpf_perf_event.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/bpf_perf_event.h := sh ./scripts/headers_install.sh arch/x86/include/generated/uapi/asm/bpf_perf_event.h usr/include/asm/bpf_perf_event.h

--- a/preinit/linux-headers/asm/.byteorder.h.cmd
+++ b/preinit/linux-headers/asm/.byteorder.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/byteorder.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/byteorder.h usr/include/asm/byteorder.h

--- a/preinit/linux-headers/asm/.debugreg.h.cmd
+++ b/preinit/linux-headers/asm/.debugreg.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/debugreg.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/debugreg.h usr/include/asm/debugreg.h

--- a/preinit/linux-headers/asm/.e820.h.cmd
+++ b/preinit/linux-headers/asm/.e820.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/e820.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/e820.h usr/include/asm/e820.h

--- a/preinit/linux-headers/asm/.errno.h.cmd
+++ b/preinit/linux-headers/asm/.errno.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/errno.h := sh ./scripts/headers_install.sh arch/x86/include/generated/uapi/asm/errno.h usr/include/asm/errno.h

--- a/preinit/linux-headers/asm/.fcntl.h.cmd
+++ b/preinit/linux-headers/asm/.fcntl.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/fcntl.h := sh ./scripts/headers_install.sh arch/x86/include/generated/uapi/asm/fcntl.h usr/include/asm/fcntl.h

--- a/preinit/linux-headers/asm/.hw_breakpoint.h.cmd
+++ b/preinit/linux-headers/asm/.hw_breakpoint.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/hw_breakpoint.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/hw_breakpoint.h usr/include/asm/hw_breakpoint.h

--- a/preinit/linux-headers/asm/.hwcap2.h.cmd
+++ b/preinit/linux-headers/asm/.hwcap2.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/hwcap2.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/hwcap2.h usr/include/asm/hwcap2.h

--- a/preinit/linux-headers/asm/.ioctl.h.cmd
+++ b/preinit/linux-headers/asm/.ioctl.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/ioctl.h := sh ./scripts/headers_install.sh arch/x86/include/generated/uapi/asm/ioctl.h usr/include/asm/ioctl.h

--- a/preinit/linux-headers/asm/.ioctls.h.cmd
+++ b/preinit/linux-headers/asm/.ioctls.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/ioctls.h := sh ./scripts/headers_install.sh arch/x86/include/generated/uapi/asm/ioctls.h usr/include/asm/ioctls.h

--- a/preinit/linux-headers/asm/.ipcbuf.h.cmd
+++ b/preinit/linux-headers/asm/.ipcbuf.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/ipcbuf.h := sh ./scripts/headers_install.sh arch/x86/include/generated/uapi/asm/ipcbuf.h usr/include/asm/ipcbuf.h

--- a/preinit/linux-headers/asm/.ist.h.cmd
+++ b/preinit/linux-headers/asm/.ist.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/ist.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/ist.h usr/include/asm/ist.h

--- a/preinit/linux-headers/asm/.kvm.h.cmd
+++ b/preinit/linux-headers/asm/.kvm.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/kvm.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/kvm.h usr/include/asm/kvm.h

--- a/preinit/linux-headers/asm/.kvm_para.h.cmd
+++ b/preinit/linux-headers/asm/.kvm_para.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/kvm_para.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/kvm_para.h usr/include/asm/kvm_para.h

--- a/preinit/linux-headers/asm/.kvm_perf.h.cmd
+++ b/preinit/linux-headers/asm/.kvm_perf.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/kvm_perf.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/kvm_perf.h usr/include/asm/kvm_perf.h

--- a/preinit/linux-headers/asm/.ldt.h.cmd
+++ b/preinit/linux-headers/asm/.ldt.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/ldt.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/ldt.h usr/include/asm/ldt.h

--- a/preinit/linux-headers/asm/.mce.h.cmd
+++ b/preinit/linux-headers/asm/.mce.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/mce.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/mce.h usr/include/asm/mce.h

--- a/preinit/linux-headers/asm/.mman.h.cmd
+++ b/preinit/linux-headers/asm/.mman.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/mman.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/mman.h usr/include/asm/mman.h

--- a/preinit/linux-headers/asm/.msgbuf.h.cmd
+++ b/preinit/linux-headers/asm/.msgbuf.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/msgbuf.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/msgbuf.h usr/include/asm/msgbuf.h

--- a/preinit/linux-headers/asm/.msr.h.cmd
+++ b/preinit/linux-headers/asm/.msr.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/msr.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/msr.h usr/include/asm/msr.h

--- a/preinit/linux-headers/asm/.mtrr.h.cmd
+++ b/preinit/linux-headers/asm/.mtrr.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/mtrr.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/mtrr.h usr/include/asm/mtrr.h

--- a/preinit/linux-headers/asm/.param.h.cmd
+++ b/preinit/linux-headers/asm/.param.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/param.h := sh ./scripts/headers_install.sh arch/x86/include/generated/uapi/asm/param.h usr/include/asm/param.h

--- a/preinit/linux-headers/asm/.perf_regs.h.cmd
+++ b/preinit/linux-headers/asm/.perf_regs.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/perf_regs.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/perf_regs.h usr/include/asm/perf_regs.h

--- a/preinit/linux-headers/asm/.poll.h.cmd
+++ b/preinit/linux-headers/asm/.poll.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/poll.h := sh ./scripts/headers_install.sh arch/x86/include/generated/uapi/asm/poll.h usr/include/asm/poll.h

--- a/preinit/linux-headers/asm/.posix_types.h.cmd
+++ b/preinit/linux-headers/asm/.posix_types.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/posix_types.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/posix_types.h usr/include/asm/posix_types.h

--- a/preinit/linux-headers/asm/.posix_types_32.h.cmd
+++ b/preinit/linux-headers/asm/.posix_types_32.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/posix_types_32.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/posix_types_32.h usr/include/asm/posix_types_32.h

--- a/preinit/linux-headers/asm/.posix_types_64.h.cmd
+++ b/preinit/linux-headers/asm/.posix_types_64.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/posix_types_64.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/posix_types_64.h usr/include/asm/posix_types_64.h

--- a/preinit/linux-headers/asm/.posix_types_x32.h.cmd
+++ b/preinit/linux-headers/asm/.posix_types_x32.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/posix_types_x32.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/posix_types_x32.h usr/include/asm/posix_types_x32.h

--- a/preinit/linux-headers/asm/.prctl.h.cmd
+++ b/preinit/linux-headers/asm/.prctl.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/prctl.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/prctl.h usr/include/asm/prctl.h

--- a/preinit/linux-headers/asm/.processor-flags.h.cmd
+++ b/preinit/linux-headers/asm/.processor-flags.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/processor-flags.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/processor-flags.h usr/include/asm/processor-flags.h

--- a/preinit/linux-headers/asm/.ptrace-abi.h.cmd
+++ b/preinit/linux-headers/asm/.ptrace-abi.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/ptrace-abi.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/ptrace-abi.h usr/include/asm/ptrace-abi.h

--- a/preinit/linux-headers/asm/.ptrace.h.cmd
+++ b/preinit/linux-headers/asm/.ptrace.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/ptrace.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/ptrace.h usr/include/asm/ptrace.h

--- a/preinit/linux-headers/asm/.resource.h.cmd
+++ b/preinit/linux-headers/asm/.resource.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/resource.h := sh ./scripts/headers_install.sh arch/x86/include/generated/uapi/asm/resource.h usr/include/asm/resource.h

--- a/preinit/linux-headers/asm/.sembuf.h.cmd
+++ b/preinit/linux-headers/asm/.sembuf.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/sembuf.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/sembuf.h usr/include/asm/sembuf.h

--- a/preinit/linux-headers/asm/.setup.h.cmd
+++ b/preinit/linux-headers/asm/.setup.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/setup.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/setup.h usr/include/asm/setup.h

--- a/preinit/linux-headers/asm/.sgx.h.cmd
+++ b/preinit/linux-headers/asm/.sgx.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/sgx.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/sgx.h usr/include/asm/sgx.h

--- a/preinit/linux-headers/asm/.shmbuf.h.cmd
+++ b/preinit/linux-headers/asm/.shmbuf.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/shmbuf.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/shmbuf.h usr/include/asm/shmbuf.h

--- a/preinit/linux-headers/asm/.sigcontext.h.cmd
+++ b/preinit/linux-headers/asm/.sigcontext.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/sigcontext.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/sigcontext.h usr/include/asm/sigcontext.h

--- a/preinit/linux-headers/asm/.sigcontext32.h.cmd
+++ b/preinit/linux-headers/asm/.sigcontext32.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/sigcontext32.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/sigcontext32.h usr/include/asm/sigcontext32.h

--- a/preinit/linux-headers/asm/.siginfo.h.cmd
+++ b/preinit/linux-headers/asm/.siginfo.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/siginfo.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/siginfo.h usr/include/asm/siginfo.h

--- a/preinit/linux-headers/asm/.signal.h.cmd
+++ b/preinit/linux-headers/asm/.signal.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/signal.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/signal.h usr/include/asm/signal.h

--- a/preinit/linux-headers/asm/.socket.h.cmd
+++ b/preinit/linux-headers/asm/.socket.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/socket.h := sh ./scripts/headers_install.sh arch/x86/include/generated/uapi/asm/socket.h usr/include/asm/socket.h

--- a/preinit/linux-headers/asm/.sockios.h.cmd
+++ b/preinit/linux-headers/asm/.sockios.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/sockios.h := sh ./scripts/headers_install.sh arch/x86/include/generated/uapi/asm/sockios.h usr/include/asm/sockios.h

--- a/preinit/linux-headers/asm/.stat.h.cmd
+++ b/preinit/linux-headers/asm/.stat.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/stat.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/stat.h usr/include/asm/stat.h

--- a/preinit/linux-headers/asm/.statfs.h.cmd
+++ b/preinit/linux-headers/asm/.statfs.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/statfs.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/statfs.h usr/include/asm/statfs.h

--- a/preinit/linux-headers/asm/.svm.h.cmd
+++ b/preinit/linux-headers/asm/.svm.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/svm.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/svm.h usr/include/asm/svm.h

--- a/preinit/linux-headers/asm/.swab.h.cmd
+++ b/preinit/linux-headers/asm/.swab.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/swab.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/swab.h usr/include/asm/swab.h

--- a/preinit/linux-headers/asm/.termbits.h.cmd
+++ b/preinit/linux-headers/asm/.termbits.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/termbits.h := sh ./scripts/headers_install.sh arch/x86/include/generated/uapi/asm/termbits.h usr/include/asm/termbits.h

--- a/preinit/linux-headers/asm/.termios.h.cmd
+++ b/preinit/linux-headers/asm/.termios.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/termios.h := sh ./scripts/headers_install.sh arch/x86/include/generated/uapi/asm/termios.h usr/include/asm/termios.h

--- a/preinit/linux-headers/asm/.types.h.cmd
+++ b/preinit/linux-headers/asm/.types.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/types.h := sh ./scripts/headers_install.sh arch/x86/include/generated/uapi/asm/types.h usr/include/asm/types.h

--- a/preinit/linux-headers/asm/.ucontext.h.cmd
+++ b/preinit/linux-headers/asm/.ucontext.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/ucontext.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/ucontext.h usr/include/asm/ucontext.h

--- a/preinit/linux-headers/asm/.unistd.h.cmd
+++ b/preinit/linux-headers/asm/.unistd.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/unistd.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/unistd.h usr/include/asm/unistd.h

--- a/preinit/linux-headers/asm/.unistd_32.h.cmd
+++ b/preinit/linux-headers/asm/.unistd_32.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/unistd_32.h := sh ./scripts/headers_install.sh arch/x86/include/generated/uapi/asm/unistd_32.h usr/include/asm/unistd_32.h

--- a/preinit/linux-headers/asm/.unistd_64.h.cmd
+++ b/preinit/linux-headers/asm/.unistd_64.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/unistd_64.h := sh ./scripts/headers_install.sh arch/x86/include/generated/uapi/asm/unistd_64.h usr/include/asm/unistd_64.h

--- a/preinit/linux-headers/asm/.unistd_x32.h.cmd
+++ b/preinit/linux-headers/asm/.unistd_x32.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/unistd_x32.h := sh ./scripts/headers_install.sh arch/x86/include/generated/uapi/asm/unistd_x32.h usr/include/asm/unistd_x32.h

--- a/preinit/linux-headers/asm/.vm86.h.cmd
+++ b/preinit/linux-headers/asm/.vm86.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/vm86.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/vm86.h usr/include/asm/vm86.h

--- a/preinit/linux-headers/asm/.vmx.h.cmd
+++ b/preinit/linux-headers/asm/.vmx.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/vmx.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/vmx.h usr/include/asm/vmx.h

--- a/preinit/linux-headers/asm/.vsyscall.h.cmd
+++ b/preinit/linux-headers/asm/.vsyscall.h.cmd
@@ -1,1 +1,0 @@
-cmd_usr/include/asm/vsyscall.h := sh ./scripts/headers_install.sh arch/x86/include/uapi/asm/vsyscall.h usr/include/asm/vsyscall.h


### PR DESCRIPTION
## Summary
- remove generated `*.cmd` files from preinit/linux-headers
- ignore future `*.cmd` files under preinit/linux-headers in `.gitignore`

## Testing
- `make -C preinit` *(fails: `i486-linux-gcc: No such file or directory`)*