### PR TITLE
Add 720K image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Run the build scripts in this order:
 
 On my machine (Ryzen 1700x, 16GB RAM), building the toolchain takes around ten minutes; building Linux takes around a minute, and the remaining steps take less than a minute each.
 
-After successful execution of all scripts, you should have `floppy.img` (boot image) and `modules.img` (modules). These can be `dd`'d to a 1.44M 3.5" floppy disk.
+After successful execution of all scripts, you should have `floppy.img` (boot image) and `modules.img` (modules). By default these are sized for a 1.44M disk. Pass `720` as the first argument to `build-floppy.sh` and `build-modules.sh` to create 720K images instead.
 
 ## Booting the system
 
@@ -41,4 +41,4 @@ Notes:
 
 ### Kernel compression
 
-This build now uses **LZO** compression for the kernel image. LZO decompresses much faster than the previous LZMA setting at the cost of a slightly larger `bzImage`. Even with LZO the image still fits on the 1.44M boot floppy. If you need the smallest possible image, switch back to LZMA but expect slower boot times.
+This build now uses **LZO** compression for the kernel image. LZO decompresses much faster than the previous LZMA setting but produces a `bzImage` around **1.1&nbsp;MB** with the supplied configuration. This easily fits on a 1.44M floppy but is too large for a 720K disk. For 720K targets, enable LZMA compression (`CONFIG_KERNEL_LZMA=y`) and disable unnecessary built‑ins so the final image stays under 720K.

--- a/build-floppy.sh
+++ b/build-floppy.sh
@@ -12,7 +12,15 @@ cleanup() {
 }
 trap cleanup EXIT
 
-dd if=/dev/zero of=floppy.img bs=1k count=1440
+size=${1:-1440}
+
+if [ "$size" = "720" ]; then
+    lilo_conf=/boot/lilo_720.conf
+else
+    lilo_conf=/boot/lilo.conf
+fi
+
+dd if=/dev/zero of=floppy.img bs=1k count=$size
 mkfs.ext2 -b 1024 -i 65536 -I 128 -m 0 -r 0 -T floppy -d floppy floppy.img
 
 sudo mount floppy.img /mnt -oloop
@@ -20,7 +28,7 @@ sudo mkdir /mnt/dev
 sudo mount devtmpfs /mnt/dev -t devtmpfs
 
 sudo chown -R root:root /mnt/*
-sudo lilo -v -g -b /dev/loop0 -r /mnt -C /boot/lilo.conf
+sudo lilo -v -g -b /dev/loop0 -r /mnt -C "$lilo_conf"
 
 sudo umount /mnt/dev
 sudo rmdir /mnt/dev

--- a/build-modules.sh
+++ b/build-modules.sh
@@ -21,7 +21,9 @@ du -sh ./modules
 
 echo "Creating modules.img..."
 
-dd if=/dev/zero of=modules.img bs=1k count=1440
+size=${1:-1440}
+
+dd if=/dev/zero of=modules.img bs=1k count=$size
 mkfs.vfat -F 12 modules.img
 sudo mount -oloop modules.img /mnt
 sudo cp -R modules/* /mnt/

--- a/floppy/boot/lilo_720.conf
+++ b/floppy/boot/lilo_720.conf
@@ -1,0 +1,11 @@
+disk=/dev/loop0
+bios=0
+sectors=9
+heads=2
+cylinders=80
+backup=/dev/null
+install=text
+compact
+image=/boot/bzImage
+label=linux
+append="root=/dev/ram0 rw"


### PR DESCRIPTION
## Summary
- allow building 720K floppy images
- add a 720K LILO configuration
- document new 720K options and kernel size guidance

## Testing
- `echo "No tests present" && true`