### PR TITLE
Add 720K floppy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Run the build scripts in this order:
 
 On my machine (Ryzen 1700x, 16GB RAM), building the toolchain takes around ten minutes; building Linux takes around a minute, and the remaining steps take less than a minute each.
 
-After successful execution of all scripts, you should have `floppy.img` (boot image) and `modules.img` (modules). These can be `dd`'d to a 1.44M 3.5" floppy disk.
+After successful execution of all scripts, you should have `floppy.img` (boot image) and `modules.img` (modules). These can be `dd`'d to a 1.44M 3.5" floppy disk. Pass `720` to `build-floppy.sh` if you need a 720K boot disk.
 
 ## Booting the system
 
@@ -41,4 +41,4 @@ Notes:
 
 ### Kernel compression
 
-This build now uses **LZO** compression for the kernel image. LZO decompresses much faster than the previous LZMA setting at the cost of a slightly larger `bzImage`. Even with LZO the image still fits on the 1.44M boot floppy. If you need the smallest possible image, switch back to LZMA but expect slower boot times.
+This build now uses **LZO** compression for the kernel image. LZO decompresses much faster than the previous LZMA setting at the cost of a slightly larger `bzImage`. Even with LZO the image still fits on the 1.44M boot floppy (or the 720K image generated with `build-floppy.sh 720`). If you need the smallest possible image, switch back to LZMA but expect slower boot times.

--- a/build-floppy.sh
+++ b/build-floppy.sh
@@ -12,13 +12,28 @@ cleanup() {
 }
 trap cleanup EXIT
 
-dd if=/dev/zero of=floppy.img bs=1k count=1440
+SIZE="${1:-1440}"
+if [[ "$SIZE" != "1440" && "$SIZE" != "720" ]]; then
+    echo "Usage: $0 [720|1440]" >&2
+    exit 1
+fi
+
+if [[ "$SIZE" == "720" ]]; then
+    COUNT=720
+    LILO_CONF="floppy/boot/lilo.conf.720k"
+else
+    COUNT=1440
+    LILO_CONF="floppy/boot/lilo.conf"
+fi
+
+dd if=/dev/zero of=floppy.img bs=1k count=$COUNT
 mkfs.ext2 -b 1024 -i 65536 -I 128 -m 0 -r 0 -T floppy -d floppy floppy.img
 
 sudo mount floppy.img /mnt -oloop
 sudo mkdir /mnt/dev
 sudo mount devtmpfs /mnt/dev -t devtmpfs
 
+sudo cp "$LILO_CONF" /mnt/boot/lilo.conf
 sudo chown -R root:root /mnt/*
 sudo lilo -v -g -b /dev/loop0 -r /mnt -C /boot/lilo.conf
 

--- a/floppy/boot/lilo.conf.720k
+++ b/floppy/boot/lilo.conf.720k
@@ -1,0 +1,11 @@
+disk=/dev/loop0
+bios=0
+sectors=9
+heads=2
+cylinders=80
+backup=/dev/null
+install=text
+compact
+image=/boot/bzImage
+label=linux
+append="root=/dev/ram0 rw"


### PR DESCRIPTION
## Summary
- add a `lilo.conf.720k` with sectors=9
- let `build-floppy.sh` choose a config based on size argument
- document how to build a 720K boot floppy

## Testing
- `bash -n build-floppy.sh`