### PR TITLE
Add size option for modules image

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo provides the files necessary to build a modern Linux-based "operating 
 
 The generated boot floppy disk provides you with a Busybox system that is kept entirely in memory. uClibc's shared library files are also loaded into memory, allowing other programs to save on memory (as opposed to using static binaries).
 
-A second floppy containing additional kernel modules can also be generated. Both floppies are ext2 formatted.
+A second floppy containing additional kernel modules can also be generated. The boot disk uses ext2 while the modules disk is formatted as FAT12.
 
 ## Build requirements
 
@@ -27,6 +27,8 @@ Run the build scripts in this order:
 On my machine (Ryzen 1700x, 16GB RAM), building the toolchain takes around ten minutes; building Linux takes around a minute, and the remaining steps take less than a minute each.
 
 After successful execution of all scripts, you should have `floppy.img` (boot image) and `modules.img` (modules). These can be `dd`'d to a 1.44M 3.5" floppy disk.
+
+The modules disk is FAT12 formatted and defaults to 1440 KB. You can create a smaller image by passing a size in kilobytes to `build-modules.sh`, for example `./build-modules.sh 720` for a 720 KB disk. Ensure the `modules/` directory fits within the requested size before running the script.
 
 ## Booting the system
 

--- a/build-modules.sh
+++ b/build-modules.sh
@@ -21,7 +21,29 @@ du -sh ./modules
 
 echo "Creating modules.img..."
 
-dd if=/dev/zero of=modules.img bs=1k count=1440
+# Optional first argument sets the image size in 1K blocks (default 1440)
+SIZE="${1:-1440}"
+
+# Usage helper
+if [[ "$SIZE" == "-h" || "$SIZE" == "--help" ]]; then
+    echo "Usage: $0 [size_in_kb]"
+    echo "Creates modules.img using the specified size (default 1440 KB)."
+    exit 0
+fi
+
+# Basic sanity check
+if ! [[ "$SIZE" =~ ^[0-9]+$ && "$SIZE" -gt 0 ]]; then
+    echo "Error: size must be a positive integer" >&2
+    exit 1
+fi
+
+# Warn if modules will not fit into the requested image
+MODULES_SIZE=$(du -sk modules | cut -f1)
+if [ "$MODULES_SIZE" -gt "$SIZE" ]; then
+    echo "Warning: modules folder (${MODULES_SIZE} KB) exceeds image size ${SIZE} KB" >&2
+fi
+
+dd if=/dev/zero of=modules.img bs=1k count="${SIZE}"
 mkfs.vfat -F 12 modules.img
 sudo mount -oloop modules.img /mnt
 sudo cp -R modules/* /mnt/


### PR DESCRIPTION
## Summary
- support passing a size argument to `build-modules.sh`
- validate module image size and warn if the modules won't fit
- document FAT12 modules disk and size option in README

## Testing
- `bash -n build-modules.sh`
- `bash -n build-floppy.sh`
